### PR TITLE
Added ability to organize stacks by thread

### DIFF
--- a/Prefs/Makefile
+++ b/Prefs/Makefile
@@ -1,5 +1,4 @@
 ARCHS = arm64
-TARGET = iphone:clang:11.3.1:11.3.1
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Prefs/Makefile
+++ b/Prefs/Makefile
@@ -1,4 +1,5 @@
 ARCHS = arm64
+TARGET = iphone:clang:11.3.1:11.3.1
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Prefs/Resources/Prefs.plist
+++ b/Prefs/Resources/Prefs.plist
@@ -54,6 +54,28 @@
 			<key>alternateColors</key>
 			<true/>
 		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSSwitchCell</string>
+			<key>default</key>
+			<false/>
+			<key>defaults</key>
+			<string>io.ominousness.stackxi</string>
+			<key>label</key>
+			<string>ORGANIZE_BY_THREAD</string>
+			<key>key</key>
+			<string>OrganizeByThread</string>
+			<key>alternateColors</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSGroupCell</string>
+			<key>label</key>
+			<string>ORGANIZE_BY_THREAD_DESCRIPTION</string>
+			<key>isStaticText</key>
+			<true/>
+		</dict>
 
 		<!-- Credits -->
 		<dict>

--- a/Prefs/Resources/base.lproj/Prefs.strings
+++ b/Prefs/Resources/base.lproj/Prefs.strings
@@ -2,6 +2,8 @@
   "ENABLED" = "Enabled";
   "SHOW_BUTTONS" = 'Show "Collapse" / "Clear All" buttons';
   "USE_ICONS" = "Use icons instead of text for buttons";
+  "ORGANIZE_BY_THREAD" = "Try organizing stacks by thread";
+  "ORGANIZE_BY_THREAD_DESCRIPTION" = "Organization relies on apps correctly setting a thread ID on their notifications. Not all do so you may not notice a difference with this turned on.";
   "RESPRING" = "Respring";
   "ARE_YOU_SURE_TO_RESET_PREFS" = "Are you sure you want to reset all your preferences? This cannot be undone.";
   "OK" = "OK";

--- a/Prefs/Resources/en.lproj/Prefs.strings
+++ b/Prefs/Resources/en.lproj/Prefs.strings
@@ -2,6 +2,8 @@
   "ENABLED" = "Enabled";
   "SHOW_BUTTONS" = 'Show "Collapse" / "Clear All" buttons';
   "USE_ICONS" = "Use icons instead of text for buttons";
+  "ORGANIZE_BY_THREAD" = "Try organizing stacks by thread";
+  "ORGANIZE_BY_THREAD_DESCRIPTION" = "Organization relies on apps correctly setting a thread ID on their notifications. Not all do so you may not notice a difference with this turned on.";
   "RESPRING" = "Respring";
   "ARE_YOU_SURE_TO_RESET_PREFS" = "Are you sure you want to reset all your preferences? This cannot be undone.";
   "OK" = "OK";

--- a/Tweak/Makefile
+++ b/Tweak/Makefile
@@ -1,5 +1,6 @@
 ARCHS = arm64
-TARGET = iphone:clang
+TARGET = iphone:clang:11.3.1:11.3.1
+
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Tweak/Makefile
+++ b/Tweak/Makefile
@@ -1,5 +1,5 @@
 ARCHS = arm64
-TARGET = iphone:clang:11.3.1:11.3.1
+TARGET = iphone:clang
 
 
 include $(THEOS)/makefiles/common.mk

--- a/Tweak/Tweak.h
+++ b/Tweak/Tweak.h
@@ -637,9 +637,11 @@
 @property (nonatomic,readonly) NCNotificationAction* clearAction;
 @property (nonatomic,readonly) NSDate* timestamp;
 @property (nonatomic,readonly) NCNotificationOptions* options; 
+@property (nonatomic, readonly, copy) NSString *threadIdentifier;
 
 
 -(void)sxiInsertRequest:(NCNotificationRequest *)request;
+-(NSString *)sxiStackID;
 -(void)sxiExpand;
 -(void)sxiCollapse;
 -(void)sxiClear:(BOOL)reload;

--- a/Tweak/Tweak.xm
+++ b/Tweak/Tweak.xm
@@ -8,9 +8,9 @@
 #define ICON_CLEAR_ALL_PATH @"/Library/PreferenceBundles/StackXIPrefs.bundle/SXIClearAll.png"
 #define LANG_BUNDLE_PATH @"/Library/PreferenceBundles/StackXIPrefs.bundle/StackXILocalization.bundle"
 #define TEMPWIDTH 0
-#define TEMPDURATION 0.3
+#define TEMPDURATION 0.4
 #define CLEAR_DURATION 0.2
-#define MAX_SHOW_BEHIND 2 //amount of blank notifications to show behind each stack
+#define MAX_SHOW_BEHIND 3 //amount of blank notifications to show behind each stack
 
 extern dispatch_queue_t __BBServerQueue;
 
@@ -540,15 +540,7 @@ static void fakeNotifications() {
             cell.hidden = NO;
 
             if (cell.frame.size.height != 50) {
-                float widthMultiplier;
-
-                if (cell.contentViewController.notificationRequest.sxiPositionInStack == 1) {
-                    widthMultiplier = 20;
-                } else {
-                    widthMultiplier = 25;
-                }
-
-                cell.frame = CGRectMake(cell.frame.origin.x + ((widthMultiplier / 2) * cell.contentViewController.notificationRequest.sxiPositionInStack), cell.frame.origin.y - 50, cell.frame.size.width - (widthMultiplier * cell.contentViewController.notificationRequest.sxiPositionInStack), 50);
+                cell.frame = CGRectMake(cell.frame.origin.x + (10 * cell.contentViewController.notificationRequest.sxiPositionInStack), cell.frame.origin.y - 50, cell.frame.size.width - (20 * cell.contentViewController.notificationRequest.sxiPositionInStack), 50);
             }
         }
     } else {
@@ -739,7 +731,7 @@ static void fakeNotifications() {
 
 %new
 -(CGRect)sxiGetNotificationCountFrame {
-    return CGRectMake(self.view.frame.origin.x + 11, self.view.frame.origin.y + self.view.frame.size.height - 26, self.view.frame.size.width - 21, 25);
+    return CGRectMake(self.view.frame.origin.x + 11, self.view.frame.origin.y + self.view.frame.size.height - 30, self.view.frame.size.width - 21, 25);
 }
 
 %new
@@ -774,7 +766,7 @@ static void fakeNotifications() {
         self.sxiNotificationCount.clipsToBounds = YES;
         self.sxiNotificationCount.hidden = YES;
         self.sxiNotificationCount.alpha = 0.0;
-        self.sxiNotificationCount.textColor = [[UIColor blackColor] colorWithAlphaComponent:0.55];
+        self.sxiNotificationCount.textColor = [[UIColor blackColor] colorWithAlphaComponent:0.8];
         [self.view addSubview:self.sxiNotificationCount];
 
         if (showButtons) {
@@ -824,7 +816,7 @@ static void fakeNotifications() {
     }
 
     if (lv && [lv _notificationContentView] && [lv _notificationContentView].primaryLabel && [lv _notificationContentView].primaryLabel.textColor) {
-        self.sxiNotificationCount.textColor = [[lv _notificationContentView].primaryLabel.textColor colorWithAlphaComponent:0.55];
+        self.sxiNotificationCount.textColor = [[lv _notificationContentView].primaryLabel.textColor colorWithAlphaComponent:0.8];
     }
 
     if (lv) {
@@ -832,11 +824,7 @@ static void fakeNotifications() {
         [lv _headerContentView].hidden = !self.notificationRequest.sxiVisible;
 
         if (!self.notificationRequest.sxiVisible) {
-            if (self.notificationRequest.sxiPositionInStack == 1) {
-                lv.alpha = 0.7;
-            } else {
-                lv.alpha = 0.55;
-            }
+            lv.alpha = 0.7;
         } else {
             lv.alpha = 1.0;
         }


### PR DESCRIPTION
While not perfect, this allows notifications that have thread identifiers to stack together in individual stacks. This works for the built-in SMS app. I'm not sure what other apps take advantage of threads, though. Thought it could be helpful.

![img_0884ff1a5bab-1](https://user-images.githubusercontent.com/25857/50309785-1d89e200-046e-11e9-972d-151986c141e9.jpeg)

